### PR TITLE
chore: upgrade MetaMask action npm publish to v6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,6 +103,7 @@ jobs:
     name: Publish release
     permissions:
       contents: write
+      id-token: write
     uses: ./.github/workflows/publish-release.yml
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       NPM_TOKEN:
-        required: true
+        required: false
       SLACK_WEBHOOK_URL:
         required: true
 
@@ -47,7 +47,7 @@ jobs:
         with:
           name: publish-release-artifacts-${{ github.sha }}
       - name: Dry Run Publish
-        uses: MetaMask/action-npm-publish@v5
+        uses: MetaMask/action-npm-publish@v6
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           subteam: S042S7RE4AE # @metamask-npm-publishers
@@ -58,6 +58,9 @@ jobs:
     needs: publish-npm-dry-run
     runs-on: ubuntu-latest
     environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v2
@@ -69,7 +72,7 @@ jobs:
         with:
           name: publish-release-artifacts-${{ github.sha }}
       - name: Publish
-        uses: MetaMask/action-npm-publish@v5
+        uses: MetaMask/action-npm-publish@v6
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
         env:

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "vite": "^6.4.1",
     "vitest": "^3.0.7"
   },
-  "packageManager": "yarn@4.10.3",
+  "packageManager": "yarn@4.16.0",
   "engines": {
     "node": "^20 || ^22 || >=24"
   },

--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     "test": "vitest && attw --pack",
     "test:watch": "vitest --watch"
   },
+  "resolutions": {
+    "fflate": "0.8.2"
+  },
   "dependencies": {
     "chalk": "^4.1.2",
     "commander": "^13.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10
 
 "@ampproject/remapping@npm:^2.2.0":

--- a/yarn.lock
+++ b/yarn.lock
@@ -3661,7 +3661,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fflate@npm:^0.8.2":
+"fflate@npm:0.8.2":
   version: 0.8.2
   resolution: "fflate@npm:0.8.2"
   checksum: 10/2bd26ba6d235d428de793c6a0cd1aaa96a06269ebd4e21b46c8fd1bd136abc631acf27e188d47c3936db090bf3e1ede11d15ce9eae9bffdc4bfe1b9dc66ca9cb


### PR DESCRIPTION
### **What?**

Moving forward, we are replacing NPM tokens with [trusted publishing using OIDC](https://docs.npmjs.com/trusted-publishers), and we are now supporting [NPM staged publishing](https://docs.npmjs.com/staged-publishing/). This is a critical step in locking down our software supply chain.

This PR upgrades to MetaMask/action-npm-publish@v6. Doing this will automatically implement the new OIDC and staged publishing changes.

The instructions for upgrading are:

- Update the publishing workflow to have id-token: write permission, and make the NPM token optional. 
- Bump the Yarn version to 4.16.0 or higher.

### **Why?**

-

### **How?**

-

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how packages are published to npm (action major version plus OIDC/token semantics), which is release-critical even though application runtime code is untouched.
> 
> **Overview**
> Upgrades release publishing from **MetaMask/action-npm-publish@v5** to **v6** on both the dry-run and real publish steps in `publish-release.yml`.
> 
> To align with v6’s publishing model, the workflow grants **`id-token: write`** on the caller `publish-release` job in `main.yml` and on the **`publish-npm`** job (with `contents: read`), and treats **`NPM_TOKEN`** as optional at the reusable workflow boundary while still passing it into the publish step when present.
> 
> Tooling lockfile updates: **Yarn** is bumped to **4.16.0** and **`fflate`** is pinned to **0.8.2** via `resolutions` in `package.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f4bbdaa08002229e2339a70ddc43c9c377f1d77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->