### PR TITLE
Add default publish workflow permissions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,6 +8,9 @@ on:
       SLACK_WEBHOOK_URL:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   publish-release:
     permissions:


### PR DESCRIPTION
### **What?**

- Added top-level `permissions: contents: read` to the publish release workflow.

### **Why?**

- Ensures the workflow has an explicit read-only default permission scope while preserving job-specific permission overrides.

### **How?**

- Updated `.github/workflows/publish-release.yml`.
- Verified the workflow now declares top-level contents read permissions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only permission scoping with no application or runtime behavior changes; existing job-level write/OIDC permissions are preserved.
> 
> **Overview**
> Adds workflow-level **`permissions: contents: read`** to `.github/workflows/publish-release.yml`, so reusable publish runs default to read-only repo access instead of inheriting broader org/repo defaults.
> 
> Job-scoped overrides are unchanged: **`publish-release`** still sets **`contents: write`** for release tagging/updates, and **`publish-npm`** still uses **`contents: read`** plus **`id-token: write`** for OIDC publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b88f085fda7e37fc8f8138926b2435baba7d20e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->